### PR TITLE
Use pg_ctlcluster to Reload Config Files

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -217,8 +217,17 @@
     mode: u=rwX,g=rwXs,o=rx
   notify: restart postgresql
 
-- name: PostgreSQL | Reload all conf files
-  service:
-    name: "{{ postgresql_service_name }}"
-    state: reloaded
+- block:
+  - name: PostgreSQL | Check if cluster is running
+    command: "pg_ctlcluster {{ postgresql_version }} {{ postgresql_cluster_name }} status"
+    ignore_errors: true
+    register: postgresql_cluster_running
+  
+  - name: PostgreSQL | Reload cluster
+    command: "pg_ctlcluster {{ postgresql_version }} {{ postgresql_cluster_name }} reload"
+    when: postgresql_cluster_running.rc == 0
+  
+  - name: PostgreSQL | Start cluster
+    command: "pg_ctlcluster {{ postgresql_version }} {{ postgresql_cluster_name }} start"
+    when: postgresql_cluster_running.rc != 0
   when: postgresql_configuration_pt1.changed or postgresql_configuration_pt2.changed or postgresql_configuration_pt3.changed or postgresql_systemd_custom_conf.changed


### PR DESCRIPTION
Since the TravisCI deployments freeze-up when you use the Ansible
service module to reload config files, use the pg_ctlcluster command to
reload the configuration files.

Fix suggested by @vladp https://github.com/ANXS/postgresql/pull/420.

Signed-off-by: Jason Rogena <jason@rogena.me>